### PR TITLE
RethinkDb was only binding to localhost.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,7 @@ Vagrant::Config.run do |config|
 			apt-get install --assume-yes rethinkdb;
 
 			sed -e 's/somebody/root/g' -e 's/somegroup/root/g' /etc/rethinkdb/default.conf.sample > /etc/rethinkdb/instances.d/default.conf
+			echo 'bind=all' >> /etc/rethinkdb/instances.d/default.conf
 
 			rethinkdb create -d /var/lib/rethinkdb/instances.d/default 2>&1;
 


### PR DESCRIPTION
Adding "bind=all" explicitly allows you to access it from outside the virtualbox, which is useful for development.

I was able to access rethinkdb last week without this line, I think the new version defaults to binding only to localhost. 
