### PR TITLE
Removing multiple forwarded port declaration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,10 +10,8 @@ Vagrant::Config.run do |config|
 
 	config.ssh.username = "vagrant"
 	config.vm.network :bridged
-	config.vm.forward_port 22, 2222
 	config.vm.forward_port 8080, 8080
 	config.vm.forward_port 28015, 28015
-	config.vm.forward_port 29015, 29015
 
 	config.vm.provision :shell do |sh|
 		sh.inline = <<-EOF


### PR DESCRIPTION
This fixes:

```
➜  rethinkdb-vagrant git:(master) ✗ ./rethinkdb.sh                                                
There were warnings and/or errors while loading your Vagrantfile
for the machine 'default'.

Your Vagrantfile was written for an earlier version of Vagrant,
and while Vagrant does the best it can to remain backwards
compatible, there are some cases where things have changed
significantly enough to warrant a message. These messages are
shown below.

Warnings:
* `config.vm.customize` calls are VirtualBox-specific. If you're
using any other provider, you'll have to use config.vm.provider in a
v2 configuration block.

Bringing machine 'default' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* Forwarded port '2222' (host port) is declared multiple times
with the protocol 'tcp'.
```
