### PR TITLE
fixes "The following settings shouldn't exist: vm"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Providers
   config.vm.provider :virtualbox do |p|
-    p.vm.customize ['modifyvm', :id, '--memory', '512', '--ioapic', 'on']
+    p.customize ['modifyvm', :id, '--memory', '512', '--ioapic', 'on']
   end
 
   # SSH


### PR DESCRIPTION
I was getting this error

```
VirtualBox Provider:
* The following settings shouldn't exist: vm
```

I had to change

`p.vm.customize` to `p.customize` to make it work
